### PR TITLE
Generating new key if current one is already in COS-dictionary.

### DIFF
--- a/library/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
+++ b/library/src/main/java/org/apache/pdfbox/pdmodel/PDResources.java
@@ -407,9 +407,10 @@ public final class PDResources implements COSObjectable
 
 		// find a unique key
 		String key;
+		int iter = dict.keySet().size() + 1;
 		do
 		{
-			key = prefix + (dict.keySet().size() + 1);
+			key = prefix + iter++;
 		}
 		while (dict.containsKey(key));
 		return COSName.getPDFName(key);


### PR DESCRIPTION
The former method version did not alter the key if it already existed in the dictionary. This could have produced an infinite loop.