### PR TITLE
Migrate from external to internal storage to fix tests

### DIFF
--- a/library/src/androidTest/AndroidManifest.xml
+++ b/library/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tom_roush.pdfbox">
-
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/encryption/TestSymmetricKeyEncryption.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/encryption/TestSymmetricKeyEncryption.java
@@ -88,7 +88,7 @@ public class TestSymmetricKeyEncryption
 
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        testResultsDir = new File(android.os.Environment.getExternalStorageDirectory(), "Download/pdfbox-test-output/crypto");
+        testResultsDir = new File(testContext.getCacheDir(), "Download/pdfbox-test-output/crypto");
         testResultsDir.mkdirs();
 
         permission = new AccessPermission();

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/multipdf/PDFMergerUtilityTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/multipdf/PDFMergerUtilityTest.java
@@ -49,7 +49,7 @@ public class PDFMergerUtilityTest
     {
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        TARGETTESTDIR = android.os.Environment.getExternalStorageDirectory() + "/Download/pdfbox-test-output/merge/";
+        TARGETTESTDIR = testContext.getCacheDir() + "/Download/pdfbox-test-output/merge/";
         new File(TARGETTESTDIR).mkdirs();
         if (!new File(TARGETTESTDIR).exists())
         {

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/CCITTFactoryTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/CCITTFactoryTest.java
@@ -50,7 +50,7 @@ public class CCITTFactoryTest
     {
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        testResultsDir = new File(android.os.Environment.getExternalStorageDirectory() +
+        testResultsDir = new File(testContext.getCacheDir() +
             "/Download/pdfbox-test-output/graphics/");
         testResultsDir.mkdirs();
     }

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/JPEGFactoryTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/JPEGFactoryTest.java
@@ -54,7 +54,7 @@ public class JPEGFactoryTest
     {
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        testResultsDir = new File(android.os.Environment.getExternalStorageDirectory() +
+        testResultsDir = new File(testContext.getCacheDir() +
             "/Download/pdfbox-test-output/graphics/");
         testResultsDir.mkdirs();
     }

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/LosslessFactoryTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/LosslessFactoryTest.java
@@ -59,7 +59,7 @@ public class LosslessFactoryTest
     {
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        testResultsDir = new File(android.os.Environment.getExternalStorageDirectory() +
+        testResultsDir = new File(testContext.getCacheDir() +
             "/Download/pdfbox-test-output/graphics/");
         testResultsDir.mkdirs();
     }

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDInlineImageTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDInlineImageTest.java
@@ -58,7 +58,7 @@ public class PDInlineImageTest
     {
         testContext = InstrumentationRegistry.getInstrumentation().getContext();
         PDFBoxResourceLoader.init(testContext);
-        testResultsDir = new File(android.os.Environment.getExternalStorageDirectory() +
+        testResultsDir = new File(testContext.getCacheDir() +
             "/Download/pdfbox-test-output/graphics/");
         testResultsDir.mkdirs();
     }

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/interactive/form/AlignmentTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/interactive/form/AlignmentTest.java
@@ -48,7 +48,7 @@ public class AlignmentTest
         PDFBoxResourceLoader.init(testContext);
         document = PDDocument.load(testContext.getAssets().open(IN_DIR + "/" + NAME_OF_PDF));
         acroForm = document.getDocumentCatalog().getAcroForm();
-        OUT_DIR = new File(android.os.Environment.getExternalStorageDirectory(), "Download/pdfbox-test-output");
+        OUT_DIR = new File(testContext.getCacheDir(), "Download/pdfbox-test-output");
         OUT_DIR.mkdirs();
     }
 

--- a/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/interactive/form/MultilineFieldsTest.java
+++ b/library/src/androidTest/java/com/tom_roush/pdfbox/pdmodel/interactive/form/MultilineFieldsTest.java
@@ -52,7 +52,7 @@ public class MultilineFieldsTest
         System.out.println("Working Directory = " + System.getProperty("user.dir"));
         document = PDDocument.load(testContext.getAssets().open(IN_DIR + "/" + NAME_OF_PDF));
         acroForm = document.getDocumentCatalog().getAcroForm();
-        OUT_DIR = new File(android.os.Environment.getExternalStorageDirectory(), "Download/pdfbox-test-output");
+        OUT_DIR = new File(testContext.getCacheDir(), "Download/pdfbox-test-output");
         OUT_DIR.mkdirs();
     }
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tom_roush.pdfbox.sample" >
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/sample/src/main/java/com/tom_roush/pdfbox/sample/MainActivity.java
+++ b/sample/src/main/java/com/tom_roush/pdfbox/sample/MainActivity.java
@@ -1,15 +1,10 @@
 package com.tom_roush.pdfbox.sample;
 
-import android.Manifest;
 import android.app.Activity;
-import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
-import android.os.Environment;
-import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.View;
@@ -80,18 +75,10 @@ public class MainActivity extends Activity {
         // Enable Android-style asset loading (highly recommended)
         PDFBoxResourceLoader.init(getApplicationContext());
         // Find the root of the external storage.
-        root = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+
+        root = getApplicationContext().getCacheDir();
         assetManager = getAssets();
         tv = (TextView) findViewById(R.id.statusTextView);
-
-        // Need to ask for write permissions on SDK 23 and up, this is ignored on older versions
-        if (ContextCompat.checkSelfPermission(MainActivity.this,
-            Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)
-        {
-
-            ActivityCompat.requestPermissions(MainActivity.this,
-                new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE}, 1);
-        }
     }
 
     /**


### PR DESCRIPTION
Hi, dues to some changes in Android 9 and 10, the androidTests and the sample project raise an exception when running on those versions.

Here is the exception
```
java.io.FileNotFoundException: /storage/emulated/0/Download/pdfbox-test-output/crypto/innerFile.pdf: open failed: EACCES (Permission denied)
	at libcore.io.IoBridge.open(IoBridge.java:492)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:236)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:186)
	at com.tom_roush.pdfbox.encryption.TestSymmetricKeyEncryption.extractEmbeddedFile(TestSymmetricKeyEncryption.java:347)
	at com.tom_roush.pdfbox.encryption.TestSymmetricKeyEncryption.testProtectionInnerAttachment(TestSymmetricKeyEncryption.java:231)
	at java.lang.reflect.Method.invoke(Native Method)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at android.support.test.internal.runner.junit4.statement.RunBefores.evaluate(RunBefores.java:80)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at android.support.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
	at android.support.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:384)
	at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2205)
Caused by: android.system.ErrnoException: open failed: EACCES (Permission denied)
	at libcore.io.Linux.open(Native Method)
	at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:254)
	at libcore.io.ForwardingOs.open(ForwardingOs.java:166)
	at android.app.ActivityThread$AndroidOs.open(ActivityThread.java:7542)
	at libcore.io.IoBridge.open(IoBridge.java:478)
	... 32 more
```

To fix thoses, I move them from the external to internal storage, since this change it's not related to PdfBox-Android library itself, but only to the sample projecto and androidTests.