### PR TITLE
replace `getPixel` with `getPixels`, which makes it 10 times faster

### DIFF
--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/color/PDDeviceGray.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/color/PDDeviceGray.java
@@ -81,19 +81,23 @@ public final class PDDeviceGray extends PDDeviceColorSpace
 
         int width = raster.getWidth();
         int height = raster.getHeight();
+        int[] imgPixels = new int[width];
 
         Bitmap image = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        int[] outPixels = new int[width];
 
         int gray;
         int rgb;
         for (int y = 0; y < height; y++)
         {
+            raster.getPixels(imgPixels, 0, width, 0, y, width, 1);
             for (int x = 0; x < width; x++)
             {
-                gray = Color.alpha(raster.getPixel(x, y));
+                gray = Color.alpha(imgPixels[x]);
                 rgb = Color.argb(255, gray, gray, gray);
-                image.setPixel(x, y, rgb);
+                outPixels[x] = rgb;
             }
+            image.setPixels(outPixels, 0, width, 0, y, width, 1);
         }
 
         return image;

--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/CCITTFactory.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/CCITTFactory.java
@@ -69,16 +69,18 @@ public final class CCITTFactory
 
         int height = image.getHeight();
         int width = image.getWidth();
+        int[] pixels = new int[width];
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         MemoryCacheImageOutputStream mcios = new MemoryCacheImageOutputStream(bos);
 
         for (int y = 0; y < height; ++y)
         {
+            image.getPixels(pixels, 0, width, 0, y, width, 1);
             for (int x = 0; x < width; ++x)
             {
                 // flip bit to avoid having to set /BlackIs1
-                mcios.writeBits(~(image.getPixel(x, y) & 1), 1);
+                mcios.writeBits(~(pixels[x] & 1), 1);
             }
             if (mcios.getBitOffset() != 0)
             {

--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -564,39 +564,42 @@ public final class PDImageXObject extends PDXObject implements PDImage
 
         // compose to ARGB
         Bitmap masked = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        int[] outPixels = new int[width];
 
         int rgb;
-        int rgba;
         int alphaPixel;
         int alpha;
+        int[] imgPixels = new int[width];
+        int[] maskPixels = new int[width];
         for (int y = 0; y < height; y++)
         {
+            image.getPixels(imgPixels, 0, width, 0, y, width, 1);
+            mask.getPixels(maskPixels, 0, width, 0, y, width, 1);
             for (int x = 0; x < width; x++)
             {
-                rgb = image.getPixel(x, y);
-
-                alphaPixel = mask.getPixel(x, y);
+                rgb = imgPixels[x];
+                int r = Color.red(rgb);
+                int g = Color.green(rgb);
+                int b = Color.blue(rgb);
+                alphaPixel = maskPixels[x];
                 if (isSoft)
                 {
                     alpha = Color.alpha(alphaPixel);
                     if (matte != null && Float.compare(alpha, 0) != 0)
                     {
-                        rgb = Color.rgb(
-                            clampColor(((Color.red(rgb) / 255F - matte[0]) / (alpha / 255F) + matte[0]) * 255),
-                            clampColor(((Color.green(rgb) / 255F - matte[1]) / (alpha / 255F) + matte[1]) * 255),
-                            clampColor(((Color.blue(rgb) / 255F - matte[2]) / (alpha / 255F) + matte[2]) * 255)
-                        );
+                        r = clampColor(((r / 255F - matte[0]) / (alpha / 255F) + matte[0]) * 255);
+                        g = clampColor(((g / 255F - matte[1]) / (alpha / 255F) + matte[1]) * 255);
+                        b = clampColor(((b / 255F - matte[2]) / (alpha / 255F) + matte[2]) * 255);
                     }
                 }
                 else
                 {
                     alpha = 255 - Color.alpha(alphaPixel);
                 }
-                rgba = Color.argb(alpha, Color.red(rgb), Color.green(rgb),
-                    Color.blue(rgb));
 
-                masked.setPixel(x, y, rgba);
+                outPixels[x] = Color.argb(alpha, r, g, b);
             }
+            masked.setPixels(outPixels, 0, width, 0, y, width, 1);
         }
 
         return masked;


### PR DESCRIPTION
getPixel is not suitable for all pixels calculating, it is too slow.
Here is a test before/ after change(with previous slim_first.pdf):
I've tested getPixels for whole image or for one row, they are nearly cost the same time. So i edit the code to handle it row by row for lower memory usage.
```text
-- getPixel
I/PDImageXObject: decode: 205, softmask: 0, type: 0
I/PDImageXObject: decode: 8, softmask: 64, type: 1
I/PDImageXObject: decode: 5, softmask: 51, type: 1
I/PDImageXObject: decode: 7, softmask: 63, type: 1
I/PDImageXObject: decode: 7, softmask: 66, type: 1
I/PDImageXObject: decode: 68, softmask: 657, type: 1

-- getPixels for row
I/PDImageXObject: decode: 205, softmask: 0, type: 0
I/PDImageXObject: decode: 6, softmask: 4, type: 1
I/PDImageXObject: decode: 5, softmask: 3, type: 1
I/PDImageXObject: decode: 6, softmask: 6, type: 1
I/PDImageXObject: decode: 7, softmask: 5, type: 1
I/PDImageXObject: decode: 67, softmask: 35, type: 1
```
replace `getImage` method in PDImageXObject.java to reproduce the log:
```java
    public Bitmap getImage(Rect region, int subsampling) throws IOException
    {
        if (region == null && subsampling == cachedImageSubsampling && cachedImage != null)
        {
            Bitmap cached = cachedImage.get();
            if (cached != null)
            {
                return cached;
            }
        }

        long start = System.currentTimeMillis();
        // get image as RGB
        Bitmap image = SampledImageReader.getRGBImage(this, region, subsampling, getColorKeyMask());
        long decodeEnd = System.currentTimeMillis();


        int maskTyp = 0;
        // soft mask (overrides explicit mask)
        PDImageXObject softMask = getSoftMask();
        if (softMask != null)
        {
            float[] matte = extractMatte(softMask);
            image = applyMask(image, softMask.getOpaqueImage(), true, matte);
            maskTyp = 1;
        }
        else
        {
            // explicit mask - to be applied only if /ImageMask true
            PDImageXObject mask = getMask();
            if (mask != null && mask.isStencil())
            {
                maskTyp = 2;
                image = applyMask(image, mask.getOpaqueImage(), false, null);
            }
        }
        long allEnd = System.currentTimeMillis();
        Log.i("PDImageXObject", String.format("decode: %d, softmask: %d, type: %d", decodeEnd - start, allEnd - decodeEnd, maskTyp));

        if (region == null && subsampling <= cachedImageSubsampling)
        {
            // only cache full-image renders, and prefer lower subsampling frequency, as lower
            // subsampling means higher quality and longer render times.
            cachedImageSubsampling = subsampling;
            cachedImage = new SoftReference<Bitmap>(image);
        }

        return image;
    }
```