### PR TITLE
add support for jpx decode/encode with JP2ForAndroid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        jcenter() // jp2-android
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.2'
@@ -19,6 +20,7 @@ allprojects {
 //        maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
         mavenCentral()
         google()
+        jcenter()
     }
 
 //    Show more warnings if desired

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     api "org.bouncycastle:bcprov-jdk15to18:1.70"
     api "org.bouncycastle:bcpkix-jdk15to18:1.70"
     api "org.bouncycastle:bcutil-jdk15to18:1.70"
+    // for jpeg2000 decode/encode
+    implementation 'com.gemalto.jp2:jp2-android:1.0.3'
 
     // Test dependencies
     testImplementation 'junit:junit:4.13.2'

--- a/library/src/main/java/com/tom_roush/pdfbox/filter/DecodeResult.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/filter/DecodeResult.java
@@ -17,6 +17,7 @@
 package com.tom_roush.pdfbox.filter;
 
 import com.tom_roush.pdfbox.cos.COSDictionary;
+import com.tom_roush.pdfbox.pdmodel.graphics.color.PDJPXColorSpace;
 
 /**
  * The result of a filter decode operation. Allows information such as color space to be
@@ -30,18 +31,18 @@ public final class DecodeResult
     public static final DecodeResult DEFAULT = new DecodeResult(new COSDictionary());
 
     private final COSDictionary parameters;
-//    private PDJPXColorSpace colorSpace; TODO: PdfBox-Android
+    private PDJPXColorSpace colorSpace;
 
     DecodeResult(COSDictionary parameters)
     {
         this.parameters = parameters;
     }
 
-//    DecodeResult(COSDictionary parameters, PDJPXColorSpace colorSpace)
-//    {
-//        this.parameters = parameters;
-//        this.colorSpace = colorSpace;
-//    } TODO: PdfBox-Android
+    DecodeResult(COSDictionary parameters, PDJPXColorSpace colorSpace)
+    {
+        this.parameters = parameters;
+        this.colorSpace = colorSpace;
+    }
 
     /**
      * Returns the stream parameters, repaired using the embedded stream data.
@@ -56,14 +57,14 @@ public final class DecodeResult
      * Returns the embedded JPX color space, if any.
      * @return the embedded JPX color space, or null if there is none.
      */
-//    public PDJPXColorSpace getJPXColorSpace()
-//    {
-//        return colorSpace;
-//    } TODO: PdfBox-Android
+    public PDJPXColorSpace getJPXColorSpace()
+    {
+        return colorSpace;
+    }
 
     // Sets the JPX color space
-//    void setColorSpace(PDJPXColorSpace colorSpace)
-//    {
-//        this.colorSpace = colorSpace;
-//    } TODO: PdfBox-Android
+    void setColorSpace(PDJPXColorSpace colorSpace)
+    {
+        this.colorSpace = colorSpace;
+    }
 }

--- a/library/src/main/java/com/tom_roush/pdfbox/filter/FilterFactory.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/filter/FilterFactory.java
@@ -47,7 +47,7 @@ public final class FilterFactory
         Filter ascii85 = new ASCII85Filter();
         Filter runLength = new RunLengthDecodeFilter();
         Filter crypt = new CryptFilter();
-//        Filter jpx = new JPXFilter();
+        Filter jpx = new JPXFilter();
 //        Filter jbig2 = new JBIG2Filter();TODO: PdfBox-Android
 
         filters.put(COSName.FLATE_DECODE, flate);
@@ -65,7 +65,7 @@ public final class FilterFactory
         filters.put(COSName.RUN_LENGTH_DECODE, runLength);
         filters.put(COSName.RUN_LENGTH_DECODE_ABBREVIATION, runLength);
         filters.put(COSName.CRYPT, crypt);
-//        filters.put(COSName.JPX_DECODE, jpx);
+        filters.put(COSName.JPX_DECODE, jpx);
 //        filters.put(COSName.JBIG2_DECODE, jbig2);TODO: PdfBox-Android
     }
 

--- a/library/src/main/java/com/tom_roush/pdfbox/filter/JPXFilter.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/filter/JPXFilter.java
@@ -1,0 +1,93 @@
+package com.tom_roush.pdfbox.filter;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.os.Build;
+
+import com.gemalto.jp2.JP2Decoder;
+import com.gemalto.jp2.JP2Encoder;
+import com.tom_roush.pdfbox.cos.COSDictionary;
+import com.tom_roush.pdfbox.cos.COSName;
+import com.tom_roush.pdfbox.io.IOUtils;
+import com.tom_roush.pdfbox.pdmodel.graphics.color.PDJPXColorSpace;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * jpx decode support is provided by JP2ForAndroid.
+ * subsampling and source region is nor support in current version(1.0.3).
+ * (source region support may be coming soon.)
+ */
+public final class JPXFilter extends Filter {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DecodeResult decode(InputStream encoded, OutputStream decoded, COSDictionary
+            parameters, int index, DecodeOptions options) throws IOException {
+        DecodeResult result = new DecodeResult(new COSDictionary());
+        result.getParameters().addAll(parameters);
+        Bitmap image = readJPX(encoded, options, result);
+
+        int arrLen = image.getWidth() * image.getHeight();
+        int[] pixels = new int[arrLen];
+        image.getPixels(pixels, 0, image.getWidth(), 0, 0, image.getWidth(), image.getHeight());
+        for (int i = 0; i < arrLen; i++) {
+            int color = pixels[i];
+            decoded.write(Color.red(color));
+            decoded.write(Color.green(color));
+            decoded.write(Color.blue(color));
+        }
+        return result;
+    }
+
+    @Override
+    public DecodeResult decode(InputStream encoded, OutputStream decoded,
+                               COSDictionary parameters, int index) throws IOException {
+        return decode(encoded, decoded, parameters, index, DecodeOptions.DEFAULT);
+    }
+
+    // try to read using JP2ForAndroid
+    private Bitmap readJPX(InputStream input, DecodeOptions options, DecodeResult result) throws IOException {
+        JP2Decoder decoder = new JP2Decoder(input);
+        // TODO: uncomment after upgrading JP2ForAndroid
+        // decoder.setSourceRegion(options.getSourceRegion());
+        Bitmap image = decoder.decode();
+
+        COSDictionary parameters = result.getParameters();
+
+        // "Decode shall be ignored, except in the case where the image is treated as a mask"
+        if (!parameters.getBoolean(COSName.IMAGE_MASK, false)) {
+            parameters.setItem(COSName.DECODE, null);
+        }
+
+        // override dimensions, see PDFBOX-1735
+        parameters.setInt(COSName.WIDTH, image.getWidth());
+        parameters.setInt(COSName.HEIGHT, image.getHeight());
+
+        // extract embedded color space
+        if (!parameters.containsKey(COSName.COLORSPACE) && Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            // COLORSPACE exists in parameters usually, so here would not be reached in most cases
+            result.setColorSpace(new PDJPXColorSpace(image.getColorSpace()));
+        }
+
+        return image;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void encode(InputStream input, OutputStream encoded, COSDictionary parameters)
+            throws IOException {
+        Bitmap bitmap = BitmapFactory.decodeStream(input);
+        byte[] jpeBytes = new JP2Encoder(bitmap).encode();
+        IOUtils.copy(new ByteArrayInputStream(jpeBytes), encoded);
+        encoded.flush();
+    }
+}

--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/color/PDJPXColorSpace.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/color/PDJPXColorSpace.java
@@ -1,0 +1,69 @@
+package com.tom_roush.pdfbox.pdmodel.graphics.color;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorSpace;
+import android.os.Build;
+
+import java.io.IOException;
+
+public class PDJPXColorSpace  extends PDColorSpace{
+    private final ColorSpace colorSpace;
+
+    /**
+     * Creates a new JPX color space from the given AWT color space.
+     * @param colorSpace AWT color space from a JPX image
+     */
+    public PDJPXColorSpace(ColorSpace colorSpace)
+    {
+        this.colorSpace = colorSpace;
+    }
+
+    @Override
+    public String getName() {
+        return "JPX";
+    }
+
+    @Override
+    public int getNumberOfComponents() {
+        if(Build.VERSION.SDK_INT > Build.VERSION_CODES.O){
+            return colorSpace.getComponentCount();
+        }
+        return 0;
+    }
+
+    @Override
+    public float[] getDefaultDecode(int bitsPerComponent) {
+        if(Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            int n = getNumberOfComponents();
+            float[] decode = new float[n * 2];
+            for (int i = 0; i < n; i++) {
+                decode[i * 2] = colorSpace.getMinValue(i);
+                decode[i * 2 + 1] = colorSpace.getMaxValue(i);
+            }
+            return decode;
+        }
+        return new float[0];
+    }
+
+    @Override
+    public PDColor getInitialColor() {
+        throw new UnsupportedOperationException("JPX color spaces don't support drawing");
+    }
+
+    @Override
+    public float[] toRGB(float[] value) throws IOException {
+        throw new UnsupportedOperationException("JPX color spaces don't support drawing");
+    }
+
+    @Override
+    public Bitmap toRGBImage(Bitmap raster) throws IOException {
+        if(Build.VERSION.SDK_INT > Build.VERSION_CODES.O){
+            Bitmap dest = Bitmap.createBitmap(raster.getWidth(), raster.getHeight(), Bitmap.Config.RGB_565, false, colorSpace);
+            Canvas canvas = new Canvas(dest);
+            canvas.drawBitmap(raster, 0, 0, null);
+            return dest;
+        }
+        return null;
+    }
+}

--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 
 import com.tom_roush.pdfbox.cos.COSArray;
@@ -126,8 +128,20 @@ public final class PDImageXObject extends PDXObject implements PDImage
         super(stream, COSName.IMAGE);
         this.resources = resources;
         List<COSName> filters = stream.getFilters();
+        // JPX would be decode twice in rending. here is no need. just to ensure no parameters is missing.
         if (filters != null && !filters.isEmpty() && COSName.JPX_DECODE.equals(filters.get(filters.size()-1)))
         {
+            // skip decode jpx is no parameters is missing. see PDFBOX-5375 PDFBOX-3340
+            List<COSName> requireKeys = Arrays.asList(COSName.WIDTH, COSName.HEIGHT, COSName.COLORSPACE);
+            boolean needDecode = false;
+            COSStream cos = stream.getCOSObject();
+            for(COSName k : requireKeys){
+                if(!cos.containsKey(k)){
+                    needDecode = true;
+                    break;
+                }
+            }
+            if(!needDecode)return;
             COSInputStream is = null;
             try
             {

--- a/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/pdmodel/graphics/image/PDImageXObject.java
@@ -134,7 +134,8 @@ public final class PDImageXObject extends PDXObject implements PDImage
                 is = stream.createInputStream();
                 DecodeResult decodeResult = is.getDecodeResult();
                 stream.getCOSObject().addAll(decodeResult.getParameters());
-//                this.colorSpace = decodeResult.getJPXColorSpace(); TODO: PdfBox-Android
+                // getJPXColorSpace would be null in most cases
+                this.colorSpace = decodeResult.getJPXColorSpace();
             }
             finally
             {

--- a/library/src/test/java/com/tom_roush/pdfbox/filter/TestFilters.java
+++ b/library/src/test/java/com/tom_roush/pdfbox/filter/TestFilters.java
@@ -100,7 +100,7 @@ public class TestFilters
                     // Skip filters that don't currently support roundtripping
                     if( filter instanceof DCTFilter ||
                         filter instanceof CCITTFaxFilter ||
-//                        filter instanceof JPXFilter ||
+                        filter instanceof JPXFilter ||
 //                        filter instanceof JBIG2Filter || TODO: PdfBox-Android
                         filter instanceof RunLengthDecodeFilter )
                     {


### PR DESCRIPTION
[slim_first.pdf](https://github.com/TomRoush/PdfBox-Android/files/8308530/slim_first.pdf)
This is a pdf with many jpx images, which can not be print while converting pdf to image.
[JP2ForAndroid](https://github.com/ThalesGroup/JP2ForAndroid) is a java wrapper for [OpenJPEG](https://www.openjpeg.org/).
I imported JP2ForAndroid as a depence to encode/decode jpx for pdfbox

Althought `android.graphics.ColorSpace` is used in this commit, it appears only in `PDJPXColorSpace`, which would only be used in  `JPXFilter` when `Build.VERSION.SDK_INT > Build.VERSION_CODES.O` and COLORSPACE not exists in cos parameters.
In fact, most jpx objects has  COLORSPACE in its cos parameters.
On the other hand, in api < 26,  `PDImageXObject.colorSpace` would be null and it can be created from COLORSPACE when needed.

So, the jpx support would also works fine in  api < 26