### PR TITLE
Add support for annotation opacity via constantOpacity 

### DIFF
--- a/library/src/main/java/com/tom_roush/pdfbox/rendering/PageDrawer.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/rendering/PageDrawer.java
@@ -277,12 +277,14 @@ public class PageDrawer extends PDFGraphicsStreamEngine
     // returns an integer for color that Android understands from the PDColor
     // TODO: alpha?
     private int getColor(PDColor color) throws IOException {
+        double alphaConstant = this.getGraphicsState().getAlphaConstant();
         PDColorSpace colorSpace = color.getColorSpace();
         float[] floats = colorSpace.toRGB(color.getComponents());
+        int alpha = Long.valueOf(Math.round(alphaConstant * 255.0)).intValue();
         int r = Math.round(floats[0] * 255);
         int g = Math.round(floats[1] * 255);
         int b = Math.round(floats[2] * 255);
-        return Color.rgb(r, g, b);
+        return Color.argb(alpha, r, g, b);
     }
 
     /**


### PR DESCRIPTION
With this change PdfBox-Android now renders annotations that have constantOpacity set with the correct opacity. 

You need to make a judgement on whether this can affect other parts of drawing, as I am not yet properly familiar with all the workings of PdfBox/PdfBox-Android. 

Got it working for the example document attached in issue #402 