### PR TITLE
Update R8/ProGuard rules to avoid crash in release

### DIFF
--- a/library/consumer-proguard-rules.txt
+++ b/library/consumer-proguard-rules.txt
@@ -2,3 +2,5 @@
 -keep,allowobfuscation class * extends com.tom_roush.pdfbox.pdmodel.encryption.SecurityHandler {
    public <init>(...);
 }
+
+ -keep,allowobfuscation class com.tom_roush.pdfbox.pdmodel.documentinterchange.** { *; }


### PR DESCRIPTION
The following exception in `PDFMergerUtility` happened without the additional keep-rule:

```
java.io.IOException: Error while trying to create value in number tree:com.tom_roush.pdfbox.pdmodel.documentinterchange.logicalstructure.PDParentTreeValue.<init> [class com.tom_roush.pdfbox.cos.COSArray]
     at com.tom_roush.pdfbox.multipdf.PDFMergerUtility.getNumberTreeAsMap(PDFMergerUtility.java:20)
     at com.tom_roush.pdfbox.multipdf.PDFMergerUtility.appendDocument(PDFMergerUtility.java:189)
     at com.tom_roush.pdfbox.multipdf.PDFMergerUtility.mergeDocuments(PDFMergerUtility.java:18)
Caused by: java.lang.NoSuchMethodException: com.tom_roush.pdfbox.pdmodel.documentinterchange.logicalstructure.PDParentTreeValue.<init> [class com.tom_roush.pdfbox.cos.COSArray]
     at java.lang.Class.getConstructor0(Class.java:2332)
     at java.lang.Class.getDeclaredConstructor(Class.java:2170)
     at com.tom_roush.pdfbox.multipdf.PDFMergerUtility.getNumberTreeAsMap(PDFMergerUtility.java:16)
```