### PR TITLE
Add missing proguard rules

### DIFF
--- a/library/consumer-proguard-rules.txt
+++ b/library/consumer-proguard-rules.txt
@@ -4,3 +4,6 @@
 }
 
  -keep,allowobfuscation class com.tom_roush.pdfbox.pdmodel.documentinterchange.** { *; }
+
+-dontwarn com.gemalto.jp2.JP2Decoder
+-dontwarn com.gemalto.jp2.JP2Encoder


### PR DESCRIPTION
Hi,
My project uses PdfBox-Android and everything was working great.
But when I upgraded AGP to 8.0.0 it switches automatically to proguard full mode, and that broke my builds.
```
ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/user/Developer/Project/app/build/outputs/mapping/adhoc/missing_rules.txt.
ERROR: R8: Missing class com.gemalto.jp2.JP2Decoder (referenced from: android.graphics.Bitmap com.tom_roush.pdfbox.filter.JPXFilter.readJPX(java.io.InputStream, com.tom_roush.pdfbox.filter.DecodeOptions, com.tom_roush.pdfbox.filter.DecodeResult))
Missing class com.gemalto.jp2.JP2Encoder (referenced from: void com.tom_roush.pdfbox.filter.JPXFilter.encode(java.io.InputStream, java.io.OutputStream, com.tom_roush.pdfbox.cos.COSDictionary))
```

The missing_rules.txt file add the following content.

```
# Please add these rules to your existing keep rules in order to suppress warnings.
# This is generated automatically by the Android Gradle plugin.
-dontwarn com.gemalto.jp2.JP2Decoder
-dontwarn com.gemalto.jp2.JP2Encoder
```

I tried to add those to my proguard file and it fixed the builds.

So I'm creating this PR to make the proguard rules more complete and easier to use for everyone.