### PR TITLE
fix:  drawGlyph2D error

### DIFF
--- a/library/src/main/java/com/tom_roush/pdfbox/rendering/PageDrawer.java
+++ b/library/src/main/java/com/tom_roush/pdfbox/rendering/PageDrawer.java
@@ -407,7 +407,8 @@ public class PageDrawer extends PDFGraphicsStreamEngine
         PDGraphicsState state = getGraphicsState();
         RenderingMode renderingMode = state.getTextState().getRenderingMode();
 
-        Path path = glyph2D.getPathForCharacterCode(code);
+        Path oldPath = glyph2D.getPathForCharacterCode(code);
+        Path path = new Path(oldPath);
         if (path != null)
         {
             // Stretch non-embedded glyph if it does not match the height/width contained in the PDF.


### PR DESCRIPTION
[apple.pdf](https://github.com/TomRoush/PdfBox-Android/files/14137567/apple.pdf)


When I PageDrawer call drawGlyph2D, Glyph2D is CIDType0Glyph2D, if getPathForCharacterCode returns the Path that was Cache, it will result in the character not being drawn.
In the apple.pdf I uploaded, the character "Hello world",only the first 'l' will be drawn.
I used 'Path oldPath = glyph2D.getPathForCharacterCode(code);
        Path path = new Path(oldPath);' solved the problem, although 'new Path' is expensive, but I didn't find any other solution
